### PR TITLE
DRAKEN-4270: Skip non-FileAttachment entries in GraphMapper

### DIFF
--- a/src/main/java/se/sundsvall/emailreader/integration/graph/GraphMapper.java
+++ b/src/main/java/se/sundsvall/emailreader/integration/graph/GraphMapper.java
@@ -176,12 +176,10 @@ public class GraphMapper {
 	public List<AttachmentEntity> toAttachments(final List<Attachment> attachments) {
 		return Optional.ofNullable(attachments)
 			.orElse(emptyList()).stream()
-			.map(attachment -> {
-				if (attachment instanceof final FileAttachment fileAttachment) {
-					return toAttachment(fileAttachment);
-				}
-				return null;
-			}).toList();
+			.filter(FileAttachment.class::isInstance)
+			.map(FileAttachment.class::cast)
+			.map(this::toAttachment)
+			.toList();
 	}
 
 	private AttachmentEntity toAttachment(final FileAttachment attachment) {

--- a/src/test/java/se/sundsvall/emailreader/integration/graph/GraphMapperTest.java
+++ b/src/test/java/se/sundsvall/emailreader/integration/graph/GraphMapperTest.java
@@ -4,6 +4,7 @@ import com.microsoft.graph.models.Attachment;
 import com.microsoft.graph.models.EmailAddress;
 import com.microsoft.graph.models.FileAttachment;
 import com.microsoft.graph.models.InternetMessageHeader;
+import com.microsoft.graph.models.ItemAttachment;
 import com.microsoft.graph.models.ItemBody;
 import com.microsoft.graph.models.Message;
 import com.microsoft.graph.models.Recipient;
@@ -93,6 +94,26 @@ class GraphMapperTest {
 		assertThat(result.getFirst().getName()).isEqualTo("test.txt");
 		assertThat(result.getFirst().getContentType()).isEqualTo("text/plain");
 		assertThat(result.getFirst().getContent()).isEqualTo(blob);
+	}
+
+	@Test
+	void toAttachmentsSkipsNonFileAttachments() {
+		final var fileAttachment = new FileAttachment();
+		fileAttachment.setName("test.txt");
+		fileAttachment.setContentBytes("Test Content".getBytes());
+		fileAttachment.setContentType("text/plain");
+
+		when(blobBuilder.createBlob(any())).thenReturn(blob);
+
+		final var result = graphMapper.toAttachments(List.of(new ItemAttachment(), fileAttachment, new ItemAttachment()));
+
+		assertThat(result).hasSize(1).doesNotContainNull();
+		assertThat(result.getFirst().getName()).isEqualTo("test.txt");
+	}
+
+	@Test
+	void toAttachmentsHandlesNullInput() {
+		assertThat(graphMapper.toAttachments(null)).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
Returning null for non-FileAttachment items left nulls in the EmailEntity attachments collection, causing Hibernate to NPE during OneToMany FK update flush. Filter them out instead.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
