### PR TITLE
hydran-xyz-sonar-issues

### DIFF
--- a/src/main/java/se/sundsvall/emailreader/integration/db/entity/AttachmentEntity.java
+++ b/src/main/java/se/sundsvall/emailreader/integration/db/entity/AttachmentEntity.java
@@ -14,6 +14,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.sql.Blob;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -57,7 +58,7 @@ public class AttachmentEntity {
 
 	@PrePersist
 	void prePersist() {
-		createdAt = LocalDateTime.now();
+		createdAt = LocalDateTime.now(ZoneId.systemDefault());
 	}
 
 }

--- a/src/main/java/se/sundsvall/emailreader/integration/db/entity/CredentialsEntity.java
+++ b/src/main/java/se/sundsvall/emailreader/integration/db/entity/CredentialsEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -76,7 +77,7 @@ public class CredentialsEntity {
 
 	@PrePersist
 	void prePersist() {
-		createdAt = LocalDateTime.now();
+		createdAt = LocalDateTime.now(ZoneId.systemDefault());
 	}
 
 }

--- a/src/main/java/se/sundsvall/emailreader/integration/db/entity/EmailEntity.java
+++ b/src/main/java/se/sundsvall/emailreader/integration/db/entity/EmailEntity.java
@@ -14,6 +14,7 @@ import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -106,7 +107,7 @@ public class EmailEntity {
 
 	@PrePersist
 	void prePersist() {
-		createdAt = OffsetDateTime.now();
+		createdAt = OffsetDateTime.now(ZoneId.systemDefault());
 		linkChildren();
 	}
 

--- a/src/main/java/se/sundsvall/emailreader/integration/db/entity/GraphCredentialsEntity.java
+++ b/src/main/java/se/sundsvall/emailreader/integration/db/entity/GraphCredentialsEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -77,6 +78,6 @@ public class GraphCredentialsEntity {
 
 	@PrePersist
 	void prePersist() {
-		createdAt = OffsetDateTime.now();
+		createdAt = OffsetDateTime.now(ZoneId.systemDefault());
 	}
 }

--- a/src/main/java/se/sundsvall/emailreader/service/EmailService.java
+++ b/src/main/java/se/sundsvall/emailreader/service/EmailService.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -107,7 +108,7 @@ public class EmailService {
 
 	public List<EmailEntity> getOldEmails() {
 		return emailRepository.findAll().stream()
-			.filter(email -> email.getCreatedAt().isBefore(OffsetDateTime.now().minusDays(1)))
+			.filter(email -> email.getCreatedAt().isBefore(OffsetDateTime.now(ZoneId.systemDefault()).minusDays(1)))
 			.toList();
 	}
 


### PR DESCRIPTION
Fixes the open **java.time** SonarCloud issues in this service (`java:S8688` × 4).

> Explicitly specify the time zone by passing a ZoneId or a Clock to the `.now()` method.

Every no-arg `java.time` `.now()` call in `src/main` now passes `ZoneId.systemDefault()` explicitly, including statically imported bare `now()` calls. Behaviour unchanged, and this matches the convention already dominant across the fleet.

This touches 5 call sites — the 4 currently flagged ones plus one identical `OffsetDateTime.now()` in `EmailService.getOldEmails()` that SonarCloud has not flagged yet (its analysis lags); leaving it would just produce a new issue on the next scan.

### Verification
`mvn clean verify` — all tests green, JaCoCo coverage gate passed.

### Note on the SonarCloud quality gate
This PR may trip `new_duplicated_lines_density`. The changed lines often sit inside `@PrePersist`/`@PreUpdate` timestamp boilerplate that is near-identical across entity classes, and a PR's denominator is only the changed lines — so a few lines inside pre-existing duplicated blocks can exceed the 3% threshold. No code defect and no behaviour change; needs a reviewer override.
